### PR TITLE
添加#官方公告及相关功能

### DIFF
--- a/lib/app/newsListBBS.js
+++ b/lib/app/newsListBBS.js
@@ -1,0 +1,267 @@
+import { segment } from "oicq";
+import fetch from "node-fetch";
+import { render } from "../render.js";
+import fs from "fs";
+import common from "../common.js";
+
+//项目路径
+const _path = process.cwd();
+
+let newurl = "https://bbs-api.mihoyo.com/post/wapi/getNewsList?gids=2&page_size=5&type=1"; //米游社官方原神公告接口地址
+
+if (!fs.existsSync(`./data/PushNews/`)) {
+    fs.mkdirSync(`./data/PushNews/`);
+}
+let PushNews = {};
+
+
+//1.定义命令规则
+export const rule = {
+    newsContentBBS: {
+        reg: "^#*官方公告[0-9]*$", //匹配消息正则，命令正则
+        priority: 500, //优先级，越小优先度越高
+        describe: "【#官方公告】米游社官方公告", //【命令】功能说明
+    },
+    newsListBBS: {
+        reg: "^#*公告列表$", //匹配消息正则，命令正则
+        priority: 501, //优先级，越小优先度越高
+        describe: "【#官方公告列表】米游社官方公告列表", //【命令】功能说明
+    },
+    pushnews: {
+        reg: "^#*(开启公告推送|关闭公告推送)$", //匹配消息正则，命令正则
+        priority: 502, //优先级，越小优先度越高
+        describe: "【#开启/关闭公告推送】", //【命令】功能说明
+    },
+    // pushNewsTask: {
+    //     reg: "^测试推送$", //匹配消息正则，命令正则
+    //     priority: 502, //优先级，越小优先度越高
+    //     describe: "【#开启/关闭公告推送】", //【命令】功能说明
+    // },
+};
+
+export async function newsContentBBS(e) {
+    //e.msg 用户的命令消息
+    if (e.msg) {
+        console.log("用户命令：", e.msg);
+    }
+
+    //执行的逻辑功能
+    let url = newurl; //米游社官方原神公告接口地址
+    let response = await fetch(url); //调用接口获取数据
+    let res = await response.json(); //结果json字符串转对象
+
+    if (res.retcode != 0) {
+        return true;
+    }
+    let data = res.data.list;
+    if (data.length == 0) {
+        return true;
+    }
+
+    let page = 1;
+    if (!e.isPushTask) {
+        page = e.msg.replace(/#|＃|官方公告/g, "").trim();
+    }
+    if(!page){
+        page = 1;
+    }
+    if (page > data.length) {
+        page = 1; //todo 越界
+
+        e.reply("目前只查前5条最新的公告，请输入1-5之间的整数。")
+        return true;
+    }
+
+    let newData = data[page - 1].post;
+
+    let newsTime = new Date(newData.created_at * 1000);
+
+    if (e.isPushTask) {
+        let oldTime = new Date(e.lastPushTime);
+        if (newsTime.getTime() - oldTime.getTime() <= 0) {
+            return;
+        }
+        PushNews = JSON.parse(fs.readFileSync("./data/PushNews/PushNews.json", "utf8"));
+        PushNews[e.pushID].lastPushTime = newsTime;
+        savePushJson();
+
+        Bot.logger.mark(`newsListBBS ：${e.pushID} 符合公告推送条件，开始推送`);
+    }
+
+
+    let title = newData.subject;
+    //newData.subject  
+    //newData.content
+    // console.log(`最新公告时间：${newData.created_at}`);
+    // console.log(`image：${newData.images}`);
+    // console.log(`文字内容：${newData.structured_content}`)
+
+    let content = JSON.parse(newData.structured_content);
+
+    let dataConent = "";
+    let imageCount = 0;
+    for (const key in content) {
+        let line = content[key];
+        if (line.attributes) {
+            if (line.attributes.color) {
+                let spanTemp = `<span style="color: ${line.attributes.color};">${line.insert}</span>`;
+                if (line.attributes.bold) {
+                    spanTemp = `<strong style="color: ${line.attributes.color};">${line.insert}</strong>`;
+                }
+                dataConent += spanTemp;
+            }
+        } else if (line.insert.image) {
+            let imageURL = newData.images[imageCount];
+            let imageTemp = `<div class="ql-image-box"><img src="${imageURL}"></div>`;
+            dataConent += imageTemp;
+            imageCount++;
+        } else {
+            dataConent += `<p><span style="color: rgb(51, 51, 51);">&nbsp;</span></p>`;
+        }
+    }
+
+    newsTime = newsTime.toLocaleString();
+
+    let base64 = await render(
+        "announcement",
+        "announcement",
+        {
+            title,
+            newsTime,
+            dataConent
+        },
+        "png"
+    );
+
+    if (base64) {
+        let msg = [];
+        if (e.isPushTask) {
+            msg.push("检测到官方公告有更新:\n");
+        }
+        msg.push(segment.image(`base64://${base64}`));
+        e.reply(msg);
+    }
+    return true; //返回true 阻挡消息不再往下
+}
+
+export async function newsListBBS(e) {
+    //e.msg 用户的命令消息
+    console.log("用户命令：", e.msg);
+
+    //执行的逻辑功能
+    let url = newurl; //米游社官方原神公告接口地址
+    let response = await fetch(url); //调用接口获取数据
+    let res = await response.json(); //结果json字符串转对象
+
+    if (res.retcode != 0) {
+        return true;
+    }
+    let datas = res.data.list;
+    if (datas.length == 0) {
+        return true;
+    }
+
+    
+    datas.forEach(element => {
+        element.post.created_at = new Date(element.post.created_at * 1000).toLocaleString();
+    });
+
+
+    let base64 = await render(
+        "announcement",
+        "announcementList",
+        {
+            datas
+        },
+        "png"
+    );
+
+    if (base64) {
+        e.reply(segment.image(`base64://${base64}`));
+    }
+
+    return true; //返回true 阻挡消息不再往下
+}
+
+export async function pushnews(e) {
+    //e.msg 用户的命令消息
+    console.log("用户命令：", e.msg);
+    if(!e.isMaster && e.isGroup){
+        e.reply("Sorry , 在群里此命令仅支持我的主人操作。",true);
+        return true;
+    }
+
+    if (fs.existsSync("./data/PushNews/PushNews.json")) {
+        console.log("存在PushNews.json");
+        PushNews = JSON.parse(fs.readFileSync("./data/PushNews/PushNews.json", "utf8"));
+    } else {
+        console.log("不存在PushNews.json")
+        savePushJson();
+    }
+
+    //推送对象记录
+    let pushID = "";
+    if (e.isGroup) {
+        pushID = e.group_id;
+    } else {
+        pushID = e.user_id;
+    }
+    if (!pushID) {
+        return true;
+    }
+    if (e.msg.includes("开启")) {
+        PushNews[pushID] = { isNewsPush: true, isGroup: e.isGroup || false, lastPushTime: new Date(), startUser: e.user_id };
+        savePushJson();
+        Bot.logger.mark(`开启原神米游社公告推送:${pushID}`);
+        e.reply("原神米游社公告推送已开启，每30分钟自动检测一次是否存在新更新公告，如有更新自动发送公告内容至此。");
+    }
+
+    if (e.msg.includes("关闭")) {
+        if (PushNews[pushID]) {
+            PushNews[pushID].isNewsPush = false;
+            savePushJson();
+            Bot.logger.mark(`关闭原神米游社公告推送:${pushID}`);
+            e.reply("原神米游社公告推送已关闭");
+        } else {
+            e.reply("此处并没有开启过公告推送");
+        }
+    }
+    return true;
+}
+
+export async function savePushJson() {
+    let path = "./data/PushNews/PushNews.json";
+    fs.writeFileSync(path, JSON.stringify(PushNews, "", "\t"));
+}
+
+export async function pushNewsTask() {
+    Bot.logger.mark(`开始官方公告推送任务`);
+    if (fs.existsSync("./data/PushNews/PushNews.json")) {
+        PushNews = JSON.parse(fs.readFileSync("./data/PushNews/PushNews.json", "utf8"));
+    } else {
+        Bot.logger.mark(`不存在PushNews.json,任务结束`);
+        return;
+    }
+    //获取需要推送公告的用户
+    for (let [pushID, push] of Object.entries(PushNews)) {
+        //推送关闭
+        if (!push.isNewsPush) {
+            continue;
+        }
+        let e = { pushID, isPushTask: true, lastPushTime: push.lastPushTime };
+        e.reply = (msg) => {
+            if (push.isGroup) {
+                Bot.pickGroup(pushID).sendMsg(msg).catch((err) => {
+                    Bot.logger.mark(err);
+                });
+            } else {
+                common.relpyPrivate(pushID, msg);
+            }
+        };
+
+        await newsContentBBS(e);
+        await common.sleep(10000);
+
+    }
+    Bot.logger.mark(`官方公告推送任务结束`);
+}

--- a/lib/init.js
+++ b/lib/init.js
@@ -153,6 +153,8 @@ async function task() {
   schedule.scheduleJob("0 0/10 * * * ? ", () => YunzaiApps.dailyNote.DailyNoteTask());
   //自动签到
   schedule.scheduleJob(BotConfig.pushTask.signTime, () => YunzaiApps.dailyNote.signTask());
+  //官方公告推送
+  schedule.scheduleJob("0 0/30 * * * ? ", () => YunzaiApps.newsListBBS.pushNewsTask());
 }
 
 //加载功能

--- a/resources/announcement/announcement/announcement.css
+++ b/resources/announcement/announcement/announcement.css
@@ -1,0 +1,84 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  user-select: none;
+  font-family: "tttgbnumber";
+}
+@font-face {
+  font-family: "tttgbnumber";
+  src: url("../../font/tttgbnumber.ttf");
+  font-weight: normal;
+  font-style: normal;
+}
+.container {
+  width: 700px;
+  padding: 20px 15px 10px 15px;
+  background-color: #f5f6fb;
+}
+.head_box {
+  border-radius: 15px;
+  font-family: "tttgbnumber";
+  padding: 20px 20px;
+  position: relative;
+  box-shadow: 0 5px 10px 0 rgb(0 0 0 / 15%);
+  background-color: #f5f6fb;
+  border-radius: 15px;
+}
+.head_box .day_text {
+  font-size: 20px;
+  padding: 20px 20px 0px;
+}
+.head_box h1{
+  font-size: 30px;
+  line-height: 36px;
+}
+.head_box .updateTime {
+  position: absolute;
+  right: 15px;
+  width: auto;
+}
+body {
+  background: #f0f1f5;
+  line-height:150%;
+  color: #333;
+  font-size: 16px;
+  width: 700px;
+  transform: scale(1.2);
+  transform-origin: 0 0;
+  
+}
+.body_box{
+  padding: 20px 0px;
+}
+.data_box {
+  box-shadow: 0 5px 10px 0 rgb(0 0 0 / 15%);
+  border-radius: 15px;
+  background-color: #fff;
+  font-family: "tttgbnumber";
+  padding: 10px 10px 10px 10px;
+  font-size: 16px;
+  word-wrap: break-word;
+  word-break: break-word;
+  height: auto;
+  overflow-x: hidden;
+}
+.ql-image-box {
+  display: inline-block;
+  font-size: 0;
+  position: relative;
+  max-width: 100%;
+  margin-bottom: 15px;
+}
+.ql-image-box img{
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+  margin: auto;
+}
+.logo {
+  font-size: 14px;
+  font-family: "tttgbnumber";
+  text-align: center;
+  color: #7994a7;
+}

--- a/resources/announcement/announcement/announcement.html
+++ b/resources/announcement/announcement/announcement.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8" />
+    <link rel="shortcut icon" href="#" />
+    <link rel="stylesheet" type="text/css" href="{{_res_path}}/announcement/announcement/announcement.css?v=1.0" />
+  </head>
+  <body>
+  <div class="container" id="container">
+    <div class="head_box">
+      <h1>{{title}}</h1>
+      <h2 class="day_text">发布时间 ：{{newsTime}}</h2>
+    </div>
+    <div class="body_box">
+	    <div class="data_box"> 
+        {{@dataConent}}
+      </div>
+    </div>
+    <div class="logo">Create By Yunzai-Bot</div>
+  </div>
+  </body>
+  <script type="text/javascript"></script>
+</html>

--- a/resources/announcement/announcementList/announcementList.css
+++ b/resources/announcement/announcementList/announcementList.css
@@ -1,0 +1,134 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  user-select: none;
+  font-family: "tttgbnumber";
+}
+@font-face {
+  font-family: "tttgbnumber";
+  src: url("../../font/tttgbnumber.ttf");
+  font-weight: normal;
+  font-style: normal;
+}
+.container {
+  width: 700px;
+  padding: 20px 15px 10px 15px;
+  background-color: #f5f6fb;
+}
+.head_box {
+  border-radius: 15px;
+  font-family: "tttgbnumber";
+  padding: 20px 20px;
+  position: relative;
+  box-shadow: 0 5px 10px 0 rgb(0 0 0 / 15%);
+  background-color: #f5f6fb;
+}
+.head_box h1{
+  font-size: 30px;
+  line-height: 36px;
+  margin: 0;
+  word-break: break-word;
+  word-wrap: break-word;
+  display: block;
+}
+body {
+  background: #f0f1f5;
+  line-height:150%;
+  color: #333;
+  font-size: 16px;
+  width: 700px;
+  transform: scale(1.2);
+  transform-origin: 0 0;
+  
+}
+.body_box{
+  padding: 20px 0px;
+}
+.data_box {
+  box-shadow: 0 5px 10px 0 rgb(0 0 0 / 15%);
+  border-radius: 15px;
+  background-color: #fff;
+  font-family: "tttgbnumber";
+  padding: 10px 10px 10px 10px;
+  font-size: 16px;
+  word-wrap: break-word;
+  word-break: break-word;
+  height: auto;
+  overflow-x: hidden;
+}
+.newscard {
+  display: flex;
+  padding: 30px 30px 24px 20px;
+  border-bottom: 1px solid #ddd;
+}
+.newscard-left {
+  width: 40px;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.newscard-comment {
+  width: 40px;
+  height: 30px;
+  position: relative;
+  text-align: center;
+  display:table-cell;
+  display: table;
+  vertical-align: middle;
+}
+.newscard-info {
+  display: block;
+  margin-left: 20px;
+  padding: 8px 0 6px;
+  overflow: hidden;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+.newscard-title {
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 600;
+  color: #333;
+}
+.newscard-content {
+  display: -webkit-box;
+  margin-top: 6px;
+  color: #999;
+  overflow: hidden;
+  -o-text-overflow: ellipsis;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  line-height: 22px;
+  max-height: 66px;
+  word-break: break-word;
+  word-wrap: break-word;
+  font-size: 14px;
+  outline: none;
+}
+.newscard-time {
+  font-size: 12px;
+  color: #ccc;
+  line-height: 1;
+  margin-top: 8px;
+}
+.newscard-cover {
+  width: 242px;
+  height: 106px;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-left: 20px;
+}
+.newscard-cover img{
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+  margin: auto;
+}
+.logo {
+  font-size: 14px;
+  font-family: "tttgbnumber";
+  text-align: center;
+  color: #7994a7;
+}

--- a/resources/announcement/announcementList/announcementList.html
+++ b/resources/announcement/announcementList/announcementList.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8" />
+    <link rel="shortcut icon" href="#" />
+    <link rel="stylesheet" type="text/css" href="{{_res_path}}/announcement/announcementList/announcementList.css?v=1.0" />
+    <!-- <link rel="stylesheet" type="text/css" href="./announcementList.css?v=1.0" /> -->
+  </head>
+  <body>
+  <div class="container" id="container">
+    <div class="head_box">
+      <!-- <h1>{{title}}</h1> -->
+      <h1>官方公告列表（ 最新5条 ）</h1>
+    </div>
+    <div class="body_box">
+      <div class="data_box">
+        {{each datas data iCount}}
+          {{if iCount == datas.length - 1}}
+          <div class="newscard" style="border-bottom: 0px">
+          {{else}}
+          <div class="newscard">
+          {{/if}}
+          <div class="newscard-left">
+            <div style="height:100%;display:table;width:100%">
+               <span style="display:table-cell;text-align:center;vertical-align:middle">{{iCount + 1}}</span>
+            </div>
+          </div> 
+              <div class="newscard-info">
+                <h3 class="newscard-title">{{data.post.subject}}</h3>
+                <div class="newscard-content">{{data.post.content}}</div> 
+                <div class="newscard-time">{{data.post.created_at}}</div>
+              </div> 
+              <div class="newscard-cover">
+                <img src={{data.post.images[0]}}></img>
+              </div>
+          </div>
+          {{/each}}
+      </div> 
+    </div>
+    <div class="logo">使用【#官方公告】加上列表中公告的序号可查询公告详情，如#官方公告2</div>
+    <div class="logo">Create By Yunzai-Bot</div>
+  </div>
+  </body>
+  <script type="text/javascript"></script>
+</html>


### PR DESCRIPTION
【命令】

- 添加【#官方公告】默认输出米游社官方最新一条公告内容
- 添加【#公告列表】输出米游社官方最新5条公告清单，支持【#官方公告+序号】查看公告详情
- 添加【#开启公告推送|#关闭公告推送】每30分钟自动检测一次是否存在新官方公告，如有更新自动发送公告内容至群or私聊。
  - 此命令在群聊仅允许主人qq进行操作