### PR TITLE
增加redis容器健康检测，关闭redis外部端口以避免缓存投毒，增加了默认配置文件的docker相关备选项

### DIFF
--- a/config/config_default.js
+++ b/config/config_default.js
@@ -14,8 +14,9 @@ let config = {
     autoQuit:1,      //1-自动退小群 0-不处理
   },
 
-  //redis配置(默认配置就好，一般都不用改)
+  //redis配置(默认配置就好，一般都不用改，使用docker搭建的用户需要更改host项)
   redis: {
+    //host: "redis",   //docker redis容器地址，如果使用docker请取消注释此行并注释下一行
     host: "127.0.0.1", //redis地址
     port: 6379,        //redis端口
     password: "",      //redis密码，没有密码可以为空

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       # - ./Yunzai/lib/example:/app/Yunzai-Bot/lib/example                 # 自定义js插件目录
       # - ./Yunzai/plugins:/app/Yunzai-Bot/plugins                         # 插件目录
     depends_on:
-      - redis
+      redis: { condition: service_healthy }
 
   redis:
     image: "redis:alpine"
@@ -22,5 +22,8 @@ services:
     volumes:
       - ./redis/data:/data
       - ./redis/logs:/logs
-    ports:
-      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "PING"]
+      start_period: 10s
+      interval: 5s
+      timeout: 1s


### PR DESCRIPTION
修改了docker-compose.yaml,使bot能够在redis容器正常工作的时候才启动，避免redis容器异常时启动bot，同时关闭redis外部端口，避免缓存投毒攻击。另外在config_default.js中添加了一行用于docker的redis地址配置文件（现在使用docker搭建必须修改redis的地址）