### PR TITLE
增加基于node:alpine的精简镜像，修复docker内的Yunzai-Bot重启命令导致停止运行的bug

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,8 @@ services:
   yunzai-bot:
     build: . # 使用 Dockerfile 本地构建
     # image: ccr.ccs.tencentyun.com/xm798/yunzai-bot:latest   # 使用镜像
-    restart: on-failure:5
+    # image: sirly/yunzai-bot:latest                          # 备用精简镜像（514M）
+    restart: always
     volumes:
       - ./Yunzai/config.js:/app/Yunzai-Bot/config/config.js # config.js 配置文件，配置文件中 redis 地址填写 "redis"
       - ./Yunzai/logs:/app/Yunzai-Bot/logs # 日志文件


### PR DESCRIPTION
在docker hub上上传了一个精简版镜像
Dockerfile
``` Docker
FROM node:alpine

WORKDIR /usr/src/app

COPY ./PingFang.ttf /usr/share/fonts/truetype/pingfang.ttf

ENV GreenBG="\\033[42;37m"\
    Font="\\033[0m" \
    Info="${Green}[信息]${Font}"

RUN apk -U --no-cache update \
    && apk -U --no-cache --allow-untrusted add libexif udev chromium nss ca-certificates git\
    && rm -rf /var/cache/*

RUN git clone https://github.com/Le-niao/Yunzai-Bot.git

WORKDIR /usr/src/app/Yunzai-Bot
COPY docker-entrypoint.sh entrypoint.sh

RUN chmod +x entrypoint.sh && npm install

ENTRYPOINT ["./entrypoint.sh"]
```
修复运行在Docker里的Yunzai-Bot在接受重启命令后容器正常退出导致无法重启的bug