### PR TITLE
修复运行在Docker内的Yunzai-Bot在执行重启命令后退出的bug，添加基于node:alpine的精简镜像

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,8 @@ services:
   yunzai-bot:
     build: . # 使用 Dockerfile 本地构建
     # image: ccr.ccs.tencentyun.com/xm798/yunzai-bot:latest   # 使用镜像
-    restart: on-failure:5
+    # image: sirly/yunzai-bot:latest                          # 备用精简镜像（514M）
+    restart: always
     volumes:
       - ./Yunzai/config.js:/app/Yunzai-Bot/config/config.js # config.js 配置文件，配置文件中 redis 地址填写 "redis"
       - ./Yunzai/logs:/app/Yunzai-Bot/logs # 日志文件

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   yunzai-bot:
     build: . # 使用 Dockerfile 本地构建
     # image: ccr.ccs.tencentyun.com/xm798/yunzai-bot:latest   # 使用镜像
-    # image: sirly/yunzai-bot:latest                          # 备用精简镜像（514M）
+    # image: swr.cn-south-1.myhuaweicloud.com/sirly/yunzai-bot:latest   # 备用精简镜像
     restart: always
     volumes:
       - ./Yunzai/config.js:/app/Yunzai-Bot/config/config.js # config.js 配置文件，配置文件中 redis 地址填写 "redis"
@@ -19,7 +19,7 @@ services:
 
   redis:
     image: "redis:alpine"
-    restart: on-failure:5
+    restart: always
     volumes:
       - ./redis/data:/data
       - ./redis/logs:/logs


### PR DESCRIPTION
修复运行在Docker内的Yunzai-Bot在执行重启命令后容器正常退出无法触发重启的问题

基于node:alpine镜像重新build了一个精简的Yunzai-Bot镜像

Dockerfile如下：
```
FROM node:current-alpine3.15

WORKDIR /app

COPY ./hk4e_zh-cn.ttf /usr/share/fonts/truetype/hk4e_zh-cn.ttf

ENV GreenBG="\\033[42;37m"\
    Font="\\033[0m" \
    Info="${Green}[信息]${Font}"

RUN apk -U --no-cache update \
    && apk upgrade \
    && apk -U --no-cache --allow-untrusted add git chromium nss freetype harfbuzz ca-certificates ttf-freefont\
    && rm -rf /var/cache/*

ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser

RUN git clone https://gitee.com/Le-niao/Yunzai-Bot.git

WORKDIR /app/Yunzai-Bot
COPY docker-entrypoint.sh entrypoint.sh

RUN chmod +x entrypoint.sh && npm install

ENTRYPOINT ["./entrypoint.sh"]
```