### PR TITLE
允许配置chromium路径

### DIFF
--- a/config/config_default.js
+++ b/config/config_default.js
@@ -136,6 +136,12 @@ let config = {
     API_KEY:    "",
     SECRET_KEY: "",
   },
+
+  // puppeteer 相关配置
+  puppeteer: {
+    // 自定义chromium路径，不填则使用npm安装的
+    executablePath: '',
+  },
 };
 
 export { config };

--- a/lib/render.js
+++ b/lib/render.js
@@ -183,7 +183,8 @@ async function browserInit() {
   //初始化puppeteer
   browser = await puppeteer
     .launch({
-      // executablePath:'',//chromium其他路径
+      // chromium其他路径
+      executablePath: (BotConfig.puppeteer || {}).executablePath || '',
       headless: global.debugView === "debug" ? false : true,
       args: [
         "--disable-gpu",


### PR DESCRIPTION
由于npm安装的chromium是不完整的，无法使用视频相关接口，导致对接椰羊的成就录屏扫描功能有问题，所以建议可以让用户自定义更改chromium的运行路径。