### PR TITLE
修复 `#五星列表`、`#练度统计` 头图背景覆盖

### DIFF
--- a/resources/genshin/talentList/talentList.css
+++ b/resources/genshin/talentList/talentList.css
@@ -42,9 +42,13 @@ body {
 
 .head_box {
   border-radius: 15px;
+  background-position-x: 30px;
+  background-repeat: no-repeat;
+  background-color: #f5f5f5;
   font-family: tttgbnumber;
   padding: 10px 20px;
   position: relative;
+  background-size: auto 101%;
   box-shadow: 0 5px 10px 0 rgb(0 0 0 / 15%);
 }
 
@@ -132,8 +136,7 @@ body {
 }
 
 .head_box {
-  background: url("../logo/namecard/雷电将军.png") no-repeat #fff;
-  background-size: auto 101%;
+  background-image: url("../logo/namecard/雷电将军.png");
 }
 
 .head_box.type2 {


### PR DESCRIPTION
我注意到命令 `#五星列表` 和 `#练度统计` 两个命令的输出头图背景目前没有完全覆盖，发现是素材右上下角自带有圆角导致的。我看到命令 `#角色` 中是使用如下的 CSS 进行渲染的：

https://github.com/Le-niao/Yunzai-Bot/blob/65607a3a328dc316d93f2e3f93a7bd76f6d47ef2/resources/genshin/roleAll/roleAll.html#L16-L25

因此在本 PR 中，我也对另外提到尚未适配的两个命令的渲染 CSS 进行了更改，使得这两个命令输出的头图全覆盖。效果：

|                                                      Before                                                      |                                                      After                                                      |
| :--------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------: |
| ![before](https://user-images.githubusercontent.com/32114380/174094968-ea6aa216-1f3e-4638-9036-77e4eabaff0a.png) | ![after](https://user-images.githubusercontent.com/32114380/174094873-d4bec04c-7181-4127-8d9c-b46137e7e238.png) |

应该是和 `#角色` 命令的渲染效果一致的。