### PR TITLE
更新 CI 流程，自动 build docker

### DIFF
--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -15,8 +15,8 @@ jobs:
       - name: install dependencies
         run: sudo apt install docker-compose
 
-      - name: pull docker images
-        run: cd docker && docker-compose up -d
+      - name: build docker images
+        run: docker-compose up -d --build
 
       - name: use default config
         run: docker cp docker/qq.yaml yunzai-bot:/app/Yunzai-Bot/config/config

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   yunzai-bot:
     container_name: yunzai-bot
-    # build: ./docker # 使用 Dockerfile 本地构建，v3.0尚在测试阶段
+    build: ./docker # 使用 Dockerfile 本地构建
     image: swr.cn-south-1.myhuaweicloud.com/sirly/yunzai-bot:dev  # 使用云端镜像
     # image: sirly/yunzai-bot:dev # Docker Hub 
     restart: always


### PR DESCRIPTION
上次的 CI 因为疏忽没有写完整，测的是固定镜像（刚 3.0 的一个版本）

现在修改为会利用 dockerfile 构建镜像并测试，现在 [actions 记录](https://github.com/YunJin77/Yunzai-Bot/actions/runs/2791277111)

可以看到 pull 了最新仓库并且通过测试（加载 11 个插件，是最新版本的数量）

顺便也测试了 dockerfile 应该是能正确建构的，@SirlyDreamer 确认一下？：）