### PR TITLE
重构米游社攻略模块，新增多个功能，优化代码逻辑

### DIFF
--- a/plugins/genshin/defSet/mys/set.yaml
+++ b/plugins/genshin/defSet/mys/set.yaml
@@ -4,5 +4,7 @@ allowUseCookie: 0
 cookieDoc: docs.qq.com/doc/DUWNVQVFTU3liTVlO
 # 米游社原神签到定时任务，Cron表达式，默认00:02开始执行，每10s签到一个，修改需要重启
 signTime: 0 2 0 * * ?
-#别名设置权限 0-所有群员都可以添加 1-群管理员才能添加 2-主人才能添加
+# 别名设置权限 0-所有群员都可以添加 1-群管理员才能添加 2-主人才能添加
 abbrSetAuth: 0
+# 米游社攻略图默认来源设置 1-西风驿站 2-原神观测枢 3-派蒙喵喵屋 4-OH是姜姜呀
+defaultSource: 1


### PR DESCRIPTION
1.增加多个来源的攻略图
2.优化获取攻略图逻辑，更改为对比图片大小来寻找
3.增加攻略说明、设置默认攻略功能

已获取过 mys.set.yaml 文件的用户，需要在文件内自行添加以下内容：
defaultSource: 1