### PR TITLE
置空 plugins/genshin/config 目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dist
 dump.rdb
 data/
 config/test/*
+plugins/genshin/config/*
 !config/test/default.yaml
 logs/
 

--- a/plugins/genshin/config/.gitignore
+++ b/plugins/genshin/config/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
置空 `plugins/genshin/config` 目录，以便 docker 可以映射该目录到主机，持久化配置。

在目录不为空的情况下，映射该目录到主机的空目录会造成 gitignore 文件丢失，影响更新。