### PR TITLE
取消默认映射端口，添加关于锅巴插件的警告

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,8 @@ services:
     # image: sirly/yunzai-bot:v3                                        # Docker Hub源
     # image: sirly/yunzai-bot:v3plus 
     restart: always
-    ports:
-      - "50831:50831"                                                   # 映射锅巴插件端口，格式"主机端口:容器内部端口"
+    # ports:
+    #   - "50831:50831"                                                 # 映射锅巴插件端口，格式"主机端口:容器内部端口"
     volumes:
       - ./yunzai/config/:/app/Yunzai-Bot/config/config/                 # Bot基础配置文件
       - ./yunzai/genshin_config:/app/Yunzai-Bot/plugins/genshin/config  # 公共Cookie，云崽功能配置文件
@@ -19,6 +19,7 @@ services:
       # - ./yunzai/plugins/miao-plugin:/app/Yunzai-Bot/plugins/miao-plugin                  # 喵喵插件
       # - ./yunzai/plugins/py-plugin:/app/Yunzai-Bot/plugins/py-plugin                      # 新py插件
       # - ./yunzai/plugins/xiaoyao-cvs-plugin:/app/Yunzai-Bot/plugins/xiaoyao-cvs-plugin    # 图鉴插件
+      #### [警告] 受云崽架构和docker特性限制，使用锅巴插件安装的插件无法持久化，销毁容器后新安装的插件会消失，请谨慎使用 ####
       # - ./yunzai/plugins/Guoba-Plugin:/app/Yunzai-Bot/plugins/Guoba-Plugin                # 锅巴插件
     depends_on:
       redis: { condition: service_healthy }

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -120,9 +120,7 @@ if [ -d $GUOBA_PLUGIN_PATH"/.git" ]; then
     if [[ ! -f "$HOME/.ovo/guoba.ok" ]]; then
         set -e
         echo -e "\n ================ \n ${Info} ${GreenBG} 更新 Guoba-Plugin 插件运行依赖 ${Font} \n ================ \n"
-        cd $WORK_DIR
-        pnpm install
-        cd $GUOBA_PLUGIN_PATH
+        pnpm add multer body-parser jsonwebtoken -w
         touch ~/.ovo/guoba.ok
         set +e
     fi


### PR DESCRIPTION
目前云崽采用本体插件化的架构，由于docker目录映射的特性，映射plugins文件夹会覆盖原目录的所有文件。

这使得目前docker安装插件极为不便，故添加警告

如果能提供单独的插件目录供docker映射，那么会方便许多