### PR TITLE
http代理模块依赖添加、用户绑定ck时判断国服和国际服的更改、国际服抽卡统计

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "pm2": "^5.2.0",
     "puppeteer": "^13.7.0",
     "redis": "^4.1.0",
-    "yaml": "^2.1.1"
+    "yaml": "^2.1.1",
+    "https-proxy-agent":"5.0.1"
   },
   "devDependencies": {
     "eslint": "^8.18.0",

--- a/plugins/genshin/model/user.js
+++ b/plugins/genshin/model/user.js
@@ -44,10 +44,6 @@ export default class User extends base {
 
     /** 拼接ck */
     this.ck = `ltoken=${param.ltoken};ltuid=${param.ltuid};cookie_token=${param.cookie_token}; account_id=${param.account_id};`
-    if (!(typeof (param.smidv2) === 'string')) {
-      //smidv2米游社特有的cookie参数
-      this.ck += ` mi18nLang=${param.mi18nLang};`// 标记这个ck是hoyolab的
-    }
     this.ltuid = param.ltuid
 
     /** 米游币签到字段 */
@@ -55,9 +51,14 @@ export default class User extends base {
 
     /** 检查ck是否失效 */
     if (!await this.checkCk()) {
-      logger.mark(`绑定cookie错误：${this.checkMsg || 'cookie错误'}`)
-      await this.e.reply(`绑定cookie失败：${this.checkMsg || 'cookie错误'}`)
-      return
+      //米游社检查ck失效,尝试使用hoyolab
+      this.ck += ` mi18nLang=${param.mi18nLang};`// 国际服的标记
+      if (!await this.checkCk()) {
+        //连hoyolab都绑不了，则是真的失效
+        logger.mark(`绑定cookie错误：${this.checkMsg || 'cookie错误'}`)
+        await this.e.reply(`绑定cookie失败：${this.checkMsg || 'cookie错误'}`)
+        return
+      }
     }
 
     logger.mark(`${this.e.logFnc} 检查cookie正常 [uid:${this.uid}]`)

--- a/plugins/genshin/model/user.js
+++ b/plugins/genshin/model/user.js
@@ -44,8 +44,9 @@ export default class User extends base {
 
     /** 拼接ck */
     this.ck = `ltoken=${param.ltoken};ltuid=${param.ltuid};cookie_token=${param.cookie_token}; account_id=${param.account_id};`
-    if (typeof (param.mi18nLang) === 'string') {
-      this.ck += ` mi18nLang=${param.mi18nLang};`// 国际服的标记
+    if (!(typeof (param.smidv2) === 'string')) {
+      //smidv2米游社特有的cookie参数
+      this.ck += ` mi18nLang=${param.mi18nLang};`// 标记这个ck是hoyolab的
     }
     this.ltuid = param.ltuid
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,56 +1,59 @@
 lockfileVersion: 5.4
 
-specifiers:
-  art-template: ^4.13.2
-  chalk: ^5.0.1
-  chokidar: ^3.5.3
-  eslint: ^8.18.0
-  eslint-config-standard: ^17.0.0
-  eslint-plugin-import: ^2.26.0
-  eslint-plugin-n: ^15.2.3
-  eslint-plugin-promise: ^6.0.0
-  express: ^4.18.1
-  express-art-template: ^1.0.1
-  inquirer: ^8.2.4
-  lodash: ^4.17.21
-  log4js: ^6.5.2
-  md5: ^2.3.0
-  moment: ^2.29.3
-  node-fetch: ^3.2.6
-  node-schedule: ^2.1.0
-  node-xlsx: ^0.21.0
-  oicq: ^2.3.1
-  pm2: ^5.2.0
-  puppeteer: ^13.7.0
-  redis: ^4.1.0
-  yaml: ^2.1.1
+importers:
 
-dependencies:
-  art-template: 4.13.2
-  chalk: 5.0.1
-  chokidar: 3.5.3
-  inquirer: 8.2.4
-  lodash: 4.17.21
-  log4js: 6.5.2
-  md5: 2.3.0
-  moment: 2.29.3
-  node-fetch: 3.2.6
-  node-schedule: 2.1.0
-  node-xlsx: 0.21.0
-  oicq: 2.3.1
-  pm2: 5.2.0
-  puppeteer: 13.7.0
-  redis: 4.1.0
-  yaml: 2.1.1
-
-devDependencies:
-  eslint: 8.18.0
-  eslint-config-standard: 17.0.0_73zqogbxxwb3ijehtqwxiag47y
-  eslint-plugin-import: 2.26.0_eslint@8.18.0
-  eslint-plugin-n: 15.2.3_eslint@8.18.0
-  eslint-plugin-promise: 6.0.0_eslint@8.18.0
-  express: 4.18.1
-  express-art-template: 1.0.1_art-template@4.13.2
+  .:
+    specifiers:
+      art-template: ^4.13.2
+      chalk: ^5.0.1
+      chokidar: ^3.5.3
+      eslint: ^8.18.0
+      eslint-config-standard: ^17.0.0
+      eslint-plugin-import: ^2.26.0
+      eslint-plugin-n: ^15.2.3
+      eslint-plugin-promise: ^6.0.0
+      express: ^4.18.1
+      express-art-template: ^1.0.1
+      https-proxy-agent: 5.0.1
+      inquirer: ^8.2.4
+      lodash: ^4.17.21
+      log4js: ^6.5.2
+      md5: ^2.3.0
+      moment: ^2.29.3
+      node-fetch: ^3.2.6
+      node-schedule: ^2.1.0
+      node-xlsx: ^0.21.0
+      oicq: ^2.3.1
+      pm2: ^5.2.0
+      puppeteer: ^13.7.0
+      redis: ^4.1.0
+      yaml: ^2.1.1
+    dependencies:
+      art-template: 4.13.2
+      chalk: 5.0.1
+      chokidar: 3.5.3
+      https-proxy-agent: 5.0.1
+      inquirer: 8.2.4
+      lodash: 4.17.21
+      log4js: 6.5.2
+      md5: 2.3.0
+      moment: 2.29.3
+      node-fetch: 3.2.6
+      node-schedule: 2.1.0
+      node-xlsx: 0.21.0
+      oicq: 2.3.1
+      pm2: 5.2.0
+      puppeteer: 13.7.0
+      redis: 4.1.0
+      yaml: 2.1.1
+    devDependencies:
+      eslint: 8.18.0
+      eslint-config-standard: 17.0.0_73zqogbxxwb3ijehtqwxiag47y
+      eslint-plugin-import: 2.26.0_eslint@8.18.0
+      eslint-plugin-n: 15.2.3_eslint@8.18.0
+      eslint-plugin-promise: 6.0.0_eslint@8.18.0
+      express: 4.18.1
+      express-art-template: 1.0.1_art-template@4.13.2
 
 packages:
 


### PR DESCRIPTION
http代理模块包的依赖添加
用户绑定ck时不再尝试根据某个参数去判断ck是米游社还是hoyolab，绑定ck时优先使用米游社接口测试ck是否失效，米游社ck失效再尝试使用hoyolab的接口进行检测，若是2个接口都失败则ck是真的失效
国际服抽卡统计功能实现(虽然挺想把plugins\genshin\model\gachaLog.js的line386-line416注释掉，当前uid没发送过抽卡链接时应该提示先私聊发送抽卡链接的)