### PR TITLE
采用npm安装`enka-network-api`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "redis": "^4.1.0",
     "yaml": "^2.1.1",
     "https-proxy-agent":"5.0.1",
-    "enka-network-api":"git+https://github.com/yuko1101/enka-network-api.git"
+    "enka-network-api":"^1.0.1"
   },
   "devDependencies": {
     "eslint": "^8.18.0",


### PR DESCRIPTION
此依赖作者已发布至npm了，可以解决由于网络问题安装不上enka-network-api的问题了。

https://github.com/yuko1101/enka-network-api/issues/1

https://www.npmjs.com/package/enka-network-api