### PR TITLE
修复`角色养成`同ck多uid时，计算数据错误

### DIFF
--- a/plugins/genshin/model/calculator.js
+++ b/plugins/genshin/model/calculator.js
@@ -24,7 +24,7 @@ export default class Calculator extends base {
       return false
     }
 
-    this.mysApi = new MysApi(ck.uid, ck.ck, { log: true })
+    this.mysApi = new MysApi(uid, ck.ck, { log: true })
 
     /** 获取角色数据 */
     let character = await this.mysApi.getData('character')


### PR DESCRIPTION
举个栗子：
同一个ck账号同时绑定官服和b服时，`角色养成`命令会计算官服