### PR TITLE
修复 #设置默认攻略 问题修复

### DIFF
--- a/plugins/genshin/apps/strategy.js
+++ b/plugins/genshin/apps/strategy.js
@@ -126,7 +126,12 @@ export class strategy extends plugin {
     let match = /^#?设置默认攻略([1-4])?$/.exec(this.e.msg)
     let set = './plugins/genshin/config/mys.set.yaml'
     let config = fs.readFileSync(set, 'utf8')
-    config = config.replace(/defaultSource: [1-4]/g, 'defaultSource: ' + Number(match[1]))
+    let num = Number(match[1])
+    if(isNaN(num)) {
+		await this.e.reply('默认攻略设置方式为: \n#设置默认攻略[1234] \n 请增加数字1-4其中一个')
+		return
+    }
+    config = config.replace(/defaultSource: [1-4]/g, 'defaultSource: ' + num)
     fs.writeFileSync(set, config, 'utf8')
 
     await this.e.reply('默认攻略已设置为: ' + match[1])


### PR DESCRIPTION
修复自己碰到的一个小问题，昨天又有人碰到了修复一下避免有人再次碰到

#设置默认攻略

直接发送给机器人 会提示 默认攻略已设置为: undefined
此时问题就会出现，之后无论你怎么再次设置，配置文件中保存的依旧是NaN，同时查询攻略时会导致后台报错 位置
Yunzai-Bot\plugins\genshin\config\mys.set.yaml

defaultSource: NaN