### PR TITLE
fix：攻略4无法下载常驻角色攻略导致报错

### DIFF
--- a/plugins/genshin/apps/strategy.js
+++ b/plugins/genshin/apps/strategy.js
@@ -157,7 +157,7 @@ export class strategy extends plugin {
       if (group == 4) {
         if (val.post.structured_content.includes(name + '】')) {
           let content = val.post.structured_content.replace(/\\\/\{\}/g, '')
-          let pattern = new RegExp(name + '】.*?image":"(.*?)"')
+          let pattern = new RegExp(name + '】.*?image\\\\?":\\\\?"(.*?)\\\\?"');  // 常驻角色兼容
           let imgId = pattern.exec(content)[1]
           for (let image of val.image_list) {
             if (image.image_id == imgId) {


### PR DESCRIPTION
查询攻略4的常驻角色，会拿不到图片数据导致下载失败报错